### PR TITLE
Reinstating exclusions with a bang

### DIFF
--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
@@ -28,6 +28,8 @@ import com.strider.dataanonymizer.requirement.Parameter;
 import com.strider.dataanonymizer.requirement.Requirement;
 import com.strider.dataanonymizer.requirement.Key;
 import com.strider.dataanonymizer.requirement.Table;
+import com.strider.dataanonymizer.requirement.Exclude;
+import com.strider.dataanonymizer.utils.LikeMatcher;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -38,7 +40,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.LinkedHashSet;
@@ -166,12 +167,48 @@ public class DatabaseAnonymizer implements IAnonymizer {
      * @param columns
      * @return 
      */
-    private String getSelectQuery(String tableName, Collection<String> columns) {
-        return String.format(
-            "SELECT %s FROM %s",
-            StringUtils.join(columns, ", "),
-            tableName
-        );
+    private PreparedStatement getSelectQueryStatement(Connection db, Table table, Collection<String> columns) throws SQLException {
+        
+        List<String> params = new LinkedList<>();
+        StringBuilder query = new StringBuilder("SELECT ");
+        query.append(StringUtils.join(columns, ", ")).append(" FROM ").append(table.getName());
+        
+        List<Exclude> exclusions = table.getExclusions();
+        if (exclusions != null) {
+            String separator = " WHERE ";
+            for (Exclude exc : exclusions) {
+                String eq = exc.getEqualsValue();
+                String lk = exc.getLikeValue();
+                boolean nl = exc.isExcludeNulls();
+                String col = exc.getName();
+
+                if (col != null && col.length() != 0) {
+                    if (eq != null) {
+                        query.append(separator).append(col).append(" != ?");
+                        params.add(eq);
+                        separator = " AND ";
+                    }
+                    if (lk != null && lk.length() != 0) {
+                        query.append(separator).append(col).append(" NOT LIKE ?");
+                        params.add(lk);
+                        separator = " AND ";
+                    }
+                    if (nl) {
+                        query.append(separator).append(col).append(" IS NOT NULL");
+                        separator = " AND ";
+                    }
+                }
+            }
+        }
+        
+        PreparedStatement stmt = db.prepareStatement(query.toString());
+        int paramIndex = 1;
+        for (String param : params) {
+            stmt.setString(paramIndex, param);
+            ++paramIndex;
+        }
+        
+        return stmt;
     }
     
     /**
@@ -187,7 +224,7 @@ public class DatabaseAnonymizer implements IAnonymizer {
      * @throws IllegalArgumentException
      * @throws InvocationTargetException 
      */
-    private String getAnonymizedValueForColumn(Column column, Connection dbConn)
+    private String callAnonymizingFunctionFor(Column column, Connection dbConn)
         throws NoSuchMethodException,
                SecurityException,
                IllegalAccessException,
@@ -225,6 +262,90 @@ public class DatabaseAnonymizer implements IAnonymizer {
         return "";
     }
     
+    private String getAnonymizedColumnValue(Connection db, ResultSet row, Column column)
+        throws SQLException,
+               NoSuchMethodException,
+               SecurityException,
+               IllegalAccessException,
+               IllegalArgumentException,
+               InvocationTargetException {
+        
+        String columnName = column.getName();
+        String columnValue = row.getString(columnName);
+        
+        List<Exclude> exclusions = column.getExclusions();
+        if (exclusions != null) {
+            for (Exclude exc : exclusions) {
+                String name = exc.getName();
+                String eq = exc.getEqualsValue();
+                String lk = exc.getLikeValue();
+                boolean nl = exc.isExcludeNulls();
+                if (name == null || name.length() == 0) {
+                    name = columnName;
+                }
+                String testValue = row.getString(name);
+
+                if (nl && testValue == null) {
+                    return columnValue;
+                } else if (eq != null && testValue.equals(eq)) {
+                    return columnValue;
+                } else if (lk != null && lk.length() != 0) {
+                    LikeMatcher matcher = new LikeMatcher(lk);
+                    if (matcher.matches(testValue)) {
+                        return columnValue;
+                    }
+                }
+            }
+        }
+
+        return callAnonymizingFunctionFor(column, db);
+    }
+    
+    private void anonymizeRow(
+        PreparedStatement updateStmt,
+        Collection<Column> tableColumns,
+        Collection<String> keyNames,
+        Collection<String> updateKeys,
+        Connection db,
+        ResultSet row
+    ) throws SQLException,
+             NoSuchMethodException,
+             SecurityException,
+             IllegalAccessException,
+             IllegalArgumentException,
+             InvocationTargetException {
+        
+        int fieldIndex = 0;
+        Set<String> updatedColumns = new HashSet<>(tableColumns.size());
+
+        for (Column column : tableColumns) {
+            String columnName = column.getName();
+            if (updatedColumns.contains(columnName)) {
+                log.warn("Column " + columnName + " is declared more than once - ignoring second definition");
+                continue;
+            }
+            updatedColumns.add(columnName);
+            ++fieldIndex;
+            
+            String colValue = getAnonymizedColumnValue(db, row, column);
+            updateStmt.setString(fieldIndex, colValue);
+        }
+
+        int nUpdateKeys = updateKeys.size();
+        int whereIndex = nUpdateKeys + fieldIndex;
+        for (String key : keyNames) {
+            String value = row.getString(key);
+            updateStmt.setString(++whereIndex, value);
+            log.debug(whereIndex + " = " + value);
+            if (updateKeys.contains(key)) {
+                updateStmt.setString(++fieldIndex, value);
+                log.debug(fieldIndex + " = " + value);
+            }
+        }
+
+        updateStmt.addBatch();
+    }
+    
     /**
      * Anonymization function for a single table.
      * 
@@ -233,16 +354,11 @@ public class DatabaseAnonymizer implements IAnonymizer {
      * 
      * @param table 
      */
-    private void anonymizeTable(int batchSize, Connection connection, Table table) {
+    private void anonymizeTable(int batchSize, Connection db, Table table) {
         
         log.info("Table [" + table.getName() + "]. Start ...");
         
         List<Column> tableColumns = table.getColumns();
-        PreparedStatement pstmt = null;
-        Statement stmt          = null;
-        ResultSet rs            = null;
-        int batchCounter        = 0;
-        
         // colNames is looked up with contains, and iterated over.  Using LinkedHashSet means
         // duplicate column names won't be added to the query, so a check in the column loop
         // below was created to ensure a reasonable warning message is logged if that happens.
@@ -252,6 +368,7 @@ public class DatabaseAnonymizer implements IAnonymizer {
         // updateKeys is used for contains() and is added to allColumns (which needs to be in
         // a predictable order) - so it needs to be a LinkedHashSet
         Set<String> updateKeys = new LinkedHashSet<>();
+        // exceptCols is added as query params
 
         fillColumnNames(table, colNames);
         fillPrimaryKeyNamesList(table, keyNames);
@@ -261,102 +378,54 @@ public class DatabaseAnonymizer implements IAnonymizer {
         allColumns.addAll(colNames);
         allColumns.addAll(updateKeys);
         
-        String selectQuery = getSelectQuery(table.getName(), allColumns);
+        // required in this scope for 'catch' block
+        PreparedStatement selectStmt = null;
+        PreparedStatement updateStmt = null;
+        ResultSet rs = null;
         
         try {
 
-            stmt = connection.createStatement();
-            rs = stmt.executeQuery(selectQuery);
+            selectStmt = getSelectQueryStatement(db, table, allColumns);
+            rs = selectStmt.executeQuery();
             
             String updateString = getUpdateQuery(table, allColumns, keyNames);
-            pstmt = connection.prepareStatement(updateString);
+            updateStmt = db.prepareStatement(updateString);
             log.debug(updateString);
             
+            int batchCounter = 0;
             while (rs.next()) {
-
-                int fieldIndex = 0;
-                Set<String> updatedColumns = new HashSet<>(tableColumns.size());
-                for (Column column : tableColumns) {
-                    
-                    String columnName = column.getName();
-                    String columnValue = rs.getString(columnName);
-                    if (updatedColumns.contains(columnName)) {
-                        log.warn("Column " + columnName + " is declared more than once - ignoring second definition");
-                        continue;
-                    }
-                    
-                    updatedColumns.add(columnName);
-                    ++fieldIndex;
-                    
-                    if (column.isIgnoreEmpty()) {
-                        if (columnValue == null || columnValue.length() == 0) {
-                            pstmt.setString(fieldIndex, columnValue);
-                            continue;
-                        }
-                    }
-                    try {
-                        String value = "";
-                        pstmt.setString(fieldIndex, value = getAnonymizedValueForColumn(column, connection));
-                        log.debug(fieldIndex + " = " + value);
-                    } catch (NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
-                        
-                        log.error(ex.toString());
-                        try {
-                            stmt.close();
-                            if (pstmt != null) {
-                                pstmt.close();
-                            }
-                            rs.close();
-                            return;
-                        } catch (SQLException sqlex) {
-                            log.error(sqlex.toString());
-                        }
-                    }
-                }
-                
-                int nUpdateKeys = updateKeys.size();
-                int whereIndex = nUpdateKeys + fieldIndex;
-                for (String key : keyNames) {
-                    String value = rs.getString(key);
-                    pstmt.setString(++whereIndex, value);
-                    log.debug(whereIndex + " = " + value);
-                    if (updateKeys.contains(key)) {
-                        pstmt.setString(++fieldIndex, value);
-                        log.debug(fieldIndex + " = " + value);
-                    }
-                }
-                
-                pstmt.addBatch();
+                anonymizeRow(updateStmt, tableColumns, keyNames, updateKeys, db, rs);
                 batchCounter++;
                 if (batchCounter == batchSize) {
-                    pstmt.executeBatch();
-                    connection.commit();
+                    updateStmt.executeBatch();
+                    db.commit();
                     batchCounter = 0;
                 }
             }
             
-            pstmt.executeBatch();
-            connection.commit();
-            stmt.close();
-            pstmt.close();
+            updateStmt.executeBatch();
+            db.commit();
+            selectStmt.close();
+            updateStmt.close();
             rs.close();
             
-        } catch (SQLException sqle) {
-            log.error(sqle.toString());
+        } catch (SQLException | NoSuchMethodException | SecurityException | IllegalAccessException | IllegalArgumentException | InvocationTargetException ex) {
+            log.error(ex.toString());
             try {
-                if (stmt != null) {
-                    stmt.close();
+                if (selectStmt != null) {
+                    selectStmt.close();
                 }
-                if (pstmt != null) {
-                    pstmt.close();
+                if (updateStmt != null) {
+                    updateStmt.close();
                 }
                 if (rs != null) {
                     rs.close();
                 }
             } catch (SQLException sqlex) {
                 log.error(sqlex.toString());
-            }                
+            }
         }
+        
         log.info("Table " + table.getName() + ". End ...");
         log.info("");
     }

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
@@ -262,6 +262,25 @@ public class DatabaseAnonymizer implements IAnonymizer {
         return "";
     }
     
+    /**
+     * Returns the anonymized value of a column, or its current value if it
+     * should be excluded.
+     * 
+     * Checks for exclusions against the current row and column values, either
+     * returning the column's current value or returning an anonymized value by
+     * calling callAnonymizingFunctionFor.
+     * 
+     * @param db
+     * @param row
+     * @param column
+     * @return the columns value
+     * @throws SQLException
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException
+     * @throws InvocationTargetException 
+     */
     private String getAnonymizedColumnValue(Connection db, ResultSet row, Column column)
         throws SQLException,
                NoSuchMethodException,
@@ -301,6 +320,25 @@ public class DatabaseAnonymizer implements IAnonymizer {
         return callAnonymizingFunctionFor(column, db);
     }
     
+    /**
+     * Anonymizes a row of columns.
+     * 
+     * Sets query parameters on the passed updateStmt - this includes the key
+     * values - and calls anonymization functions for the columns.
+     * 
+     * @param updateStmt
+     * @param tableColumns
+     * @param keyNames
+     * @param updateKeys
+     * @param db
+     * @param row
+     * @throws SQLException
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     * @throws IllegalAccessException
+     * @throws IllegalArgumentException
+     * @throws InvocationTargetException 
+     */
     private void anonymizeRow(
         PreparedStatement updateStmt,
         Collection<Column> tableColumns,

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Column.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Column.java
@@ -18,7 +18,8 @@
 
 package com.strider.dataanonymizer.requirement;
 
-import java.util.List;   
+import java.util.List;
+import java.util.ArrayList;
 import static java.util.Collections.unmodifiableList;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -47,12 +48,13 @@ public class Column {
     @XmlElement(name="ReturnType")
     private String returnType;
     
-    @XmlElement(name="Exception")
-    private String exception;            
-    
     @XmlElementWrapper(name="Parameters")
     @XmlElement(name="Parameter")
     private List<Parameter> paramters;
+    
+    @XmlElementWrapper(name="Exclusions")
+    @XmlElement(name="Exclude")
+    private List<Exclude> exclusions;
     
     /**
      * Getter method for name attribute
@@ -87,11 +89,21 @@ public class Column {
     }
     
     /**
-     * Getter method for exception attribute
-     * @return String
+     * Returns a list of exclusions
+     * 
+     * @return List<Exclude>
      */
-    public String getException() {
-        return this.exception;
+    public List<Exclude> getExclusions() {
+        if (exclusions == null && ignoreEmpty != null && ignoreEmpty.equals("true")) {
+            Exclude exc = new Exclude();
+            exc.setIgnoreEmpty();
+            exclusions = new ArrayList<>();
+            exclusions.add(exc);
+        }
+        if (this.exclusions != null) {
+            return unmodifiableList(this.exclusions);
+        }
+        return null;
     }
     
     /**
@@ -103,6 +115,5 @@ public class Column {
             return unmodifiableList(this.paramters);
         }
         return null;
-    }    
-
+    }
 }

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Exclude.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Exclude.java
@@ -1,0 +1,127 @@
+/*
+ * 
+ * Copyright 2014, Armenak Grigoryan, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+
+package com.strider.dataanonymizer.requirement;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+
+/**
+ * JAXB class definition for <Exclude> tags defining exclusion rules.
+ * 
+ * The exclude tag has a Name attribute, and either an Equals attribute, a Like
+ * attribute (corresponding to an SQL LIKE comparison), or a Null attribute.
+ * The Name attribute defines the column's name in the table, and Equals,
+ * Like, and Null attributes define the column's excluded value.
+ * 
+ * The Name attribute is optional if the exclude tag is part of a Column tag's
+ * exclusion list (the name is then the Column's name).  The Name attribute can
+ * still be included to indicate it should be excluded on the basis of the value
+ * of another column - however the other column must either be declared as a key
+ * or as a Column elsewhere in the table definition.  This restriction does not
+ * apply to table exclusions.  Any column can be used for a table exclusion.
+ * 
+ * Excluding empty values is possible by setting the Equals attribute to a blank
+ * value.  The Like attribute requires a value.
+ * 
+ * Exclude nulls with the optional Null attribute (takes a boolean value).
+ * 
+ * Note that column exclusions are not actual SQL exclusions - so some
+ * differences may apply, for instance in SQL an = comparison may be case
+ * insensitive depending on the character encoding used on the table, and the
+ * type of database being queried.
+ * 
+ * @see Table::getExclusions
+ * @see Column::getExclusions
+ * @author Zaahid Bateson
+ */
+@XmlAccessorType(XmlAccessType.FIELD)
+public class Exclude {
+    
+    /**
+     * The column name in the database
+     */
+    @XmlAttribute(name="Name")
+    private String name;
+    
+    /**
+     * The excluded value if the value should match with an SQL = comparison in
+     * the WHERE clause
+     */
+    @XmlAttribute(name="Equals")
+    private String equals;
+    
+    /**
+     * The excluded value if the value should match with an SQL LIKE comparison
+     * in the WHERE clause
+     */
+    @XmlAttribute(name="Like")
+    private String like;
+    
+    /**
+     * The excluded value includes nulls.
+     */
+    @XmlAttribute(name="Null")
+    private String excludeNull;
+    
+    /**
+     * Returns the column name represented by this exclusion
+     * 
+     * @return String
+     */
+    public String getName() {
+        return this.name;
+    }
+    
+    /**
+     * Returns the excluded (identical) value for the column
+     * 
+     * @return String
+     */
+    public String getEqualsValue() {
+        return this.equals;
+    }
+    
+    /**
+     * Returns the excluded (LIKE) value for the column
+     * 
+     * @return String
+     */
+    public String getLikeValue() {
+        return this.like;
+    }
+    
+    /**
+     * Returns true if the Null attribute is set
+     * 
+     * @return boolean
+     */
+    public boolean isExcludeNulls() {
+        return (this.excludeNull != null && this.excludeNull.equals("true"));
+    }
+    
+    /**
+     * Sets both the equals value to an empty string, and excludeNulls to "true"
+     * for the "IgnoreEmpty" shortcut.
+     */
+    public void setIgnoreEmpty() {
+        equals = "";
+        excludeNull = "true";
+    }
+}

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Table.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Table.java
@@ -50,11 +50,15 @@ public class Table {
     @XmlElement(name="Key")
     private List<Key> primaryKeys;
     
+    @XmlElementWrapper(name="Exclusions")
+    @XmlElement(name="Exclude")
+    private List<Exclude> exclusions;
+    
     /**
      * Getter method for name attribute
      * @return String
      */
-    public String getName()  {
+    public String getName() {
         return this.name;
     }
     
@@ -85,6 +89,18 @@ public class Table {
     public List<Column> getColumns() {
         if (this.columns != null) {
             return unmodifiableList(this.columns);
+        }
+        return null;
+    }
+    
+    /**
+     * Returns a list of exclusions
+     * 
+     * @return List<Exclude>
+     */
+    public List<Exclude> getExclusions() {
+        if (this.exclusions != null) {
+            return unmodifiableList(this.exclusions);
         }
         return null;
     }

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/utils/LikeMatcher.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/utils/LikeMatcher.java
@@ -1,0 +1,64 @@
+/*
+ * 
+ * Copyright 2014, Armenak Grigoryan, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+package com.strider.dataanonymizer.utils;
+
+import java.util.regex.Pattern;
+
+/**
+ * Simple matcher to mimic SQL LIKE queries.
+ * 
+ * At the moment only "%", "_" and "?" are supported.
+ * 
+ * @author Zaahid Bateson
+ */
+public class LikeMatcher {
+    
+    private String regex;
+    
+    /**
+     * Initializes a LikeMatcher with the given pattern.
+     * 
+     * @param pattern the LIKE query pattern
+     */
+    public LikeMatcher(String pattern) {
+        // splitting on '?', '_', and '%' with look-behind and look-ahead so they're included in the split array
+        String[] parts = pattern.split("((?<=[\\?\\_\\%])|(?=[\\?\\_\\%]))");
+        StringBuilder reg = new StringBuilder("^");
+        for (String part : parts) {
+            if (part.equals("%")) {
+                reg.append(".*?");
+            } else if (part.equals("?") || part.equals("_")) {
+                reg.append(".");
+            } else {
+                reg.append(Pattern.quote(part.toLowerCase()));
+            }
+        }
+        reg.append("$");
+        this.regex = reg.toString();
+    }
+    
+    /**
+     * Returns true if the given string matches the Like pattern.
+     * 
+     * @param str the string to test against
+     * @return
+     */
+    public boolean matches(String str) {
+        return str.toLowerCase().matches(regex);
+    }
+}

--- a/DataAnonymizer/src/test/java/com/strider/dataanonymizer/utils/LikeMatcherTest.java
+++ b/DataAnonymizer/src/test/java/com/strider/dataanonymizer/utils/LikeMatcherTest.java
@@ -1,0 +1,80 @@
+/*
+ * 
+ * Copyright 2014, Armenak Grigoryan, and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ */
+package com.strider.dataanonymizer.utils;
+
+import junit.framework.TestCase;
+import org.apache.log4j.Logger;
+import static org.apache.log4j.Logger.getLogger;
+
+/**
+ *
+ * @author Zaahid Bateson
+ */
+public class LikeMatcherTest extends TestCase {
+    private static Logger log = getLogger(LikeMatcherTest.class);
+    
+    public void testMatchingAtEnd() {
+        log.debug("Testing match at end of string");
+        LikeMatcher matcher = new LikeMatcher("za%");
+        assertTrue(matcher.matches("Zaahid"));
+        assertTrue(matcher.matches("ZAA"));
+        assertTrue(matcher.matches("za"));
+        assertFalse(matcher.matches("Not Zaahid"));
+        assertFalse(matcher.matches("Some Za"));
+    }
+    
+    public void testMatchingAtBeginning() {
+        log.debug("Testing match begginning of string");
+        LikeMatcher matcher = new LikeMatcher("%hid");
+        assertTrue(matcher.matches("ZaahiD"));
+        assertTrue(matcher.matches("aaHID"));
+        assertTrue(matcher.matches("HID"));
+        assertFalse(matcher.matches("Zaahid is not here"));
+        assertFalse(matcher.matches("hiding away"));
+    }
+    
+    public void testMultiMatcher() {
+        log.debug("Testing match with multiple %'s");
+        LikeMatcher matcher = new LikeMatcher("Z%h%d");
+        assertTrue(matcher.matches("ZaahiD"));
+        assertTrue(matcher.matches("ZaHID"));
+        assertTrue(matcher.matches("Zhd"));
+        assertFalse(matcher.matches("Zaahid is not here"));
+        assertFalse(matcher.matches("Someone is hiding Zaahid"));
+    }
+    
+    public void testSingleCharMatcher() {
+        log.debug("Testing match with '?' and '_'");
+        LikeMatcher matcher = new LikeMatcher("Z_?h?d");
+        assertTrue(matcher.matches("ZaahiD"));
+        assertFalse(matcher.matches("ZaHID"));
+        assertFalse(matcher.matches("Zhd"));
+        assertTrue(matcher.matches("Zaphod"));
+    }
+    
+    public void testMixedMatcher() {
+        log.debug("Testing match with a mix of '%', '?', and '_'");
+        LikeMatcher matcher = new LikeMatcher("%Z_?h?d%");
+        assertTrue(matcher.matches("ZaahiD"));
+        assertFalse(matcher.matches("ZaHID"));
+        assertFalse(matcher.matches("Zhd"));
+        assertTrue(matcher.matches("Zaphod"));
+        assertTrue(matcher.matches("Zaahid really is Zaphod"));
+        assertTrue(matcher.matches("Yes, Zaahid is here"));
+    }
+}


### PR DESCRIPTION
I mistakenly removed exclusion functionality in my last commit.  Here it is back again, but with a bit extra.

- Created new Exclude tag, can exist under either Table or Column
- Cleaned up DatabaseAnonymizer a little more

Basically, a table can have any number of excluded rows (filtered out at the select query), and a column can exclude anonymizing it's value based on the value of the column itself or any other column selected to be anonymized or specified as a key.

For more info on how it works, check out the documentation for com.strider.dataanonymizer.requirement.Exclude.