### PR TITLE
Created predictable shuffling for column values

### DIFF
--- a/DataAnonymizer/pom.xml
+++ b/DataAnonymizer/pom.xml
@@ -1,24 +1,29 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.strider</groupId>
-  <artifactId>DataAnonymizer</artifactId>
-  <version>0.1</version>
-  <packaging>jar</packaging>
+    <groupId>com.strider</groupId>
+    <artifactId>DataAnonymizer</artifactId>
+    <version>0.1</version>
+    <packaging>jar</packaging>
 
-  <name>DataAnonymizer</name>
-  <developers>
-    <developer>
-        <id>armenak.grigoryan</id>
-        <name>Armenak Grigoryan</name>
-    </developer>
-  </developers>
+    <name>DataAnonymizer</name>
+    <developers>
+        <developer>
+            <id>armenak.grigoryan</id>
+            <name>Armenak Grigoryan</name>
+        </developer>
+    </developers>
 
-  <url>http://maven.apache.org</url>
+    <url>http://maven.apache.org</url>
 
     <build>
         <plugins>
+            <!--
+                TODO:
+                look at only compiling dataanonymizer.functions and dataanonymizer.extensions with the
+                -parameters flag, which is required for method parameter reflection
+            -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -27,87 +32,88 @@
                     <source>1.7</source>
                     <target>1.7</target>
                     <showDeprecation>true</showDeprecation>
+                    <compilerArgument>-parameters</compilerArgument>
                 </configuration>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>2.2-beta-4</version>
                 <configuration>
-                  <descriptorRefs>
-                    <descriptorRef>jar-with-dependencies</descriptorRef>
-                  </descriptorRefs>
-                  <finalName>DataAnonymizer</finalName>
-                  <appendAssemblyId>false</appendAssemblyId>                  
-                  <archive>
-                    <manifest>
-                      <mainClass>com.strider.dataanonymizer.Anonymizer</mainClass>
-                    </manifest>
-                  </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <finalName>DataAnonymizer</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>                  
+                    <archive>
+                        <manifest>
+                            <mainClass>com.strider.dataanonymizer.Anonymizer</mainClass>
+                        </manifest>
+                    </archive>
                 </configuration>
                 <executions>
-                  <execution>
-                    <phase>package</phase>
-                    <goals>
-                      <goal>single</goal>
-                    </goals>
-                  </execution>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
                 </executions>
-              </plugin>
-              <plugin>
-                  <groupId>org.codehaus.mojo</groupId>
-                  <artifactId>sonar-maven-plugin</artifactId>
-                  <version>2.4</version>
-              </plugin>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>sonar-maven-plugin</artifactId>
+                <version>2.4</version>
+            </plugin>
         </plugins>
     </build>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <sonar.projectKey>DA</sonar.projectKey>
-  </properties>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonar.projectKey>DA</sonar.projectKey>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.3.2</version>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-    </dependency>    
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <version>1.2</version>
-    </dependency>     
-    <dependency>
-	<groupId>commons-configuration</groupId>
-	<artifactId>commons-configuration</artifactId>
-	<version>1.7</version>
-    </dependency>    
-    <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.30</version>
-    </dependency>   
-    <dependency>
-	<groupId>org.apache.opennlp</groupId>
-	<artifactId>opennlp-tools</artifactId>
-	<version>1.5.3</version>
-    </dependency>    
-    <dependency>
-        <groupId>dk.brics.automaton</groupId>
-        <artifactId>automaton</artifactId>
-        <version>1.11-8</version>
-    </dependency>
-  </dependencies>
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>3.8.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
+        </dependency>    
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.2</version>
+        </dependency>     
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+            <version>1.7</version>
+        </dependency>    
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.30</version>
+        </dependency>   
+        <dependency>
+            <groupId>org.apache.opennlp</groupId>
+            <artifactId>opennlp-tools</artifactId>
+            <version>1.5.3</version>
+        </dependency>    
+        <dependency>
+            <groupId>dk.brics.automaton</groupId>
+            <artifactId>automaton</artifactId>
+            <version>1.11-8</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/DataAnonymizer/src/main/resources/Requirement.xml
+++ b/DataAnonymizer/src/main/resources/Requirement.xml
@@ -27,8 +27,8 @@
                 <Column Name="description" ReturnType="String">
                     <Function>com.strider.dataanonymizer.functions.CoreFunctions.randomDescription</Function>
                     <Parameters>
-                        <Parameter Name="min" Value="1" Type="String"/>
-                        <Parameter Name="max" Value="100" Type="String"/>                        
+                        <Parameter Name="num" Value="1" Type="int"/>
+                        <Parameter Name="length" Value="100" Type="int"/>                        
                     </Parameters>
                 </Column>
                 <Column Name="student_no" ReturnType="String">

--- a/DataAnonymizer/src/test/resources/Requirement.xml
+++ b/DataAnonymizer/src/test/resources/Requirement.xml
@@ -26,8 +26,8 @@
                 <Column Name="column4" ReturnType="String">
                     <Function>com.strider.dataanonymizer.functions.CoreFunctions.randomDescription</Function>
                     <Parameters>
-                        <Parameter Name="min" Value="1" Type="String"/>
-                        <Parameter Name="max" Value="100" Type="String"/>                        
+                        <Parameter Name="num" Value="1" Type="int"/>
+                        <Parameter Name="length" Value="100" Type="int"/>                        
                     </Parameters>
                 </Column>
                 <Column Name="column5" ReturnType="String">


### PR DESCRIPTION
CoreFunctions.mappedColumnShuffle guarantees the same return value
for a given column value.

To achieve that, the reflection used to call a CoreFunction method
had to be updated so it's more strongly-typed.  Now parameters are
matched from the requirement file's Function tag by name, and the
type must either be unspecified or match the parameter definition
for the method in CoreFunctions.

Special values can be passed... this functionality may need some
cleanup to make it nicer and more predictable. At the moment a
parameter named 'value' on a CoreFunction method would be passed
the column's value.  A ResultSet 'row' parameter would be passed
the current row.