### PR TITLE
Added NotLike and NotEquals "Exclude" rules

### DIFF
--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
@@ -178,7 +178,7 @@ public class DatabaseAnonymizer implements IAnonymizer {
         
         List<Exclude> exclusions = table.getExclusions();
         if (exclusions != null) {
-            String separator = " WHERE ";
+            String separator = " WHERE (";
             for (Exclude exc : exclusions) {
                 String eq = exc.getEqualsValue();
                 String lk = exc.getLikeValue();
@@ -202,6 +202,30 @@ public class DatabaseAnonymizer implements IAnonymizer {
                     }
                 }
             }
+            
+            if (query.indexOf(" WHERE (") != -1) {
+                separator = ") AND (";
+            }
+            
+            for (Exclude exc : exclusions) {
+                String neq = exc.getNotEqualsValue();
+                String nlk = exc.getNotLikeValue();
+                String col = exc.getName();
+                
+                if (neq != null) {
+                    query.append(separator).append(col).append(" = ?");
+                    separator = " OR ";
+                }
+                if (nlk != null && nlk.length() != 0) {
+                    query.append(separator).append(col).append(" LIKE ?");
+                    separator = " OR ";
+                }
+
+            }
+            
+            if (query.indexOf(" AND ") != -1) {
+                query.append(")");
+            }
         }
         
         PreparedStatement stmt = db.prepareStatement(query.toString());
@@ -211,6 +235,9 @@ public class DatabaseAnonymizer implements IAnonymizer {
             ++paramIndex;
         }
         
+        log.debug("Querying for: " + query.toString());
+        log.debug("\t - with parameters: " + StringUtils.join(params));
+        
         return stmt;
     }
     
@@ -218,8 +245,9 @@ public class DatabaseAnonymizer implements IAnonymizer {
      * Calls the anonymization function for the given Column, and returns its
      * anonymized value.
      * 
-     * @param column
      * @param dbConn
+     * @param row
+     * @param column
      * @return
      * @throws NoSuchMethodException
      * @throws SecurityException
@@ -227,7 +255,7 @@ public class DatabaseAnonymizer implements IAnonymizer {
      * @throws IllegalArgumentException
      * @throws InvocationTargetException 
      */
-    private String callAnonymizingFunctionFor(ResultSet row, Column column, Connection dbConn)
+    private String callAnonymizingFunctionFor(Connection dbConn, ResultSet row, Column column)
         throws SQLException,
                NoSuchMethodException,
                SecurityException,
@@ -334,41 +362,30 @@ public class DatabaseAnonymizer implements IAnonymizer {
     }
     
     /**
-     * Returns the anonymized value of a column, or its current value if it
-     * should be excluded.
-     * 
-     * Checks for exclusions against the current row and column values, either
-     * returning the column's current value or returning an anonymized value by
-     * calling callAnonymizingFunctionFor.
+     * Returns true if the current column's value is excluded by the rulesets
+     * defined by the Requirements.
      * 
      * @param db
      * @param row
      * @param column
      * @return the columns value
      * @throws SQLException
-     * @throws NoSuchMethodException
-     * @throws SecurityException
-     * @throws IllegalAccessException
-     * @throws IllegalArgumentException
-     * @throws InvocationTargetException 
      */
-    private String getAnonymizedColumnValue(Connection db, ResultSet row, Column column)
-        throws SQLException,
-               NoSuchMethodException,
-               SecurityException,
-               IllegalAccessException,
-               IllegalArgumentException,
-               InvocationTargetException {
+    private boolean isExcludedColumn(Connection db, ResultSet row, Column column) throws SQLException {
         
         String columnName = column.getName();
-        String columnValue = row.getString(columnName);
         
         List<Exclude> exclusions = column.getExclusions();
+        boolean hasInclusions = false;
+        boolean passedInclusion = false;
+        
         if (exclusions != null) {
             for (Exclude exc : exclusions) {
                 String name = exc.getName();
                 String eq = exc.getEqualsValue();
                 String lk = exc.getLikeValue();
+                String neq = exc.getNotEqualsValue();
+                String nlk = exc.getNotLikeValue();
                 boolean nl = exc.isExcludeNulls();
                 if (name == null || name.length() == 0) {
                     name = columnName;
@@ -376,19 +393,33 @@ public class DatabaseAnonymizer implements IAnonymizer {
                 String testValue = row.getString(name);
 
                 if (nl && testValue == null) {
-                    return columnValue;
+                    return true;
                 } else if (eq != null && eq.equals(testValue)) {
-                    return columnValue;
+                    return true;
                 } else if (lk != null && lk.length() != 0) {
                     LikeMatcher matcher = new LikeMatcher(lk);
                     if (matcher.matches(testValue)) {
-                        return columnValue;
+                        return true;
+                    }
+                }
+                
+                if (neq != null) {
+                    hasInclusions = true;
+                    if (neq.equals(testValue)) {
+                        passedInclusion = true;
+                    }
+                }
+                if (nlk != null && nlk.length() != 0) {
+                    hasInclusions = true;
+                    LikeMatcher matcher = new LikeMatcher(nlk);
+                    if (matcher.matches(testValue)) {
+                        passedInclusion = true;
                     }
                 }
             }
         }
 
-        return callAnonymizingFunctionFor(row, column, db);
+        return (hasInclusions && !passedInclusion);
     }
     
     /**
@@ -425,19 +456,27 @@ public class DatabaseAnonymizer implements IAnonymizer {
              InvocationTargetException {
         
         int fieldIndex = 0;
-        Set<String> updatedColumns = new HashSet<>(tableColumns.size());
+        Map<String, Integer> columnIndexes = new HashMap<>(tableColumns.size());
+        Set<String> anonymized = new HashSet<>(tableColumns.size());
 
         for (Column column : tableColumns) {
             String columnName = column.getName();
-            if (updatedColumns.contains(columnName)) {
-                log.warn("Column " + columnName + " is declared more than once - ignoring second definition");
+            if (anonymized.contains(columnName)) {
                 continue;
             }
-            updatedColumns.add(columnName);
-            ++fieldIndex;
+            int columnIndex = 0;
+            if (!columnIndexes.containsKey(columnName)) {
+                columnIndex = ++fieldIndex;
+                columnIndexes.put(columnName, columnIndex);
+            }
+            if (isExcludedColumn(db, row, column)) {
+                log.debug("Excluding column: " + columnName + " with value: " + row.getString(columnName));
+                continue;
+            }
             
-            String colValue = getAnonymizedColumnValue(db, row, column);
-            updateStmt.setString(fieldIndex, colValue);
+            anonymized.add(columnName);
+            String colValue = callAnonymizingFunctionFor(db, row, column);
+            updateStmt.setString(columnIndexes.get(columnName), colValue);
         }
 
         int nUpdateKeys = updateKeys.size();

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Exclude.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Exclude.java
@@ -23,7 +23,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 
 /**
- * JAXB class definition for <Exclude> tags defining exclusion rules.
+ * JAXB class definition for &lt;Exclude&gt; tags defining exclusion rules.
  * 
  * The exclude tag has a Name attribute, and either an Equals attribute, a Like
  * attribute (corresponding to an SQL LIKE comparison), or a Null attribute.
@@ -41,6 +41,11 @@ import javax.xml.bind.annotation.XmlAttribute;
  * value.  The Like attribute requires a value.
  * 
  * Exclude nulls with the optional Null attribute (takes a boolean value).
+ * 
+ * Inclusions can be defined with the NotLike and NotEquals attribute.  In a
+ * list of &lt;Exclusions&gt; and associated &lt;Exclude&gt; tags, a column's
+ * value must match at least one NotLike or NotEquals definition if any are
+ * defined.
  * 
  * Note that column exclusions are not actual SQL exclusions - so some
  * differences may apply, for instance in SQL an = comparison may be case
@@ -75,6 +80,28 @@ public class Exclude {
     private String like;
     
     /**
+     * The excluded value if the value should match with an SQL != comparison in
+     * the WHERE clause.
+     * 
+     * NotEquals values represent "inclusions", where one NotEquals value must
+     * be matched in a series of listed <Exclusions> for the column's value to
+     * be anonymized.
+     */
+    @XmlAttribute(name="NotEquals")
+    private String notEquals;
+    
+    /**
+     * The excluded value if the value should match with an SQL NOT LIKE
+     * comparison in the WHERE clause.
+     * 
+     * NotLike values represent "inclusions", where one NotEquals value must be
+     * matched in a series of listed <Exclusions> for the column's value to be
+     * anonymized.
+     */
+    @XmlAttribute(name="NotLike")
+    private String notLike;
+    
+    /**
      * The excluded value includes nulls.
      */
     @XmlAttribute(name="Null")
@@ -105,6 +132,24 @@ public class Exclude {
      */
     public String getLikeValue() {
         return this.like;
+    }
+    
+    /**
+     * Returns the identical value that is not excluded for the column (!=)
+     * 
+     * @return String
+     */
+    public String getNotEqualsValue() {
+        return this.notEquals;
+    }
+    
+    /**
+     * Returns the (LIKE) value that is not excluded for the column (NOT LIKE)
+     * 
+     * @return String
+     */
+    public String getNotLikeValue() {
+        return this.notLike;
     }
     
     /**


### PR DESCRIPTION
NotLike and NotEquals act as "Inclusion" rules.  A column's value must match at least one NotEquals or NotLike rules to be included.

Column definitions in Requirements file may repeat the name of a single column, so different anonymization rules can be applied based on the exclusion/inclusion of column values.

This allows, for instance, anonymizing column values for specific data where the general meaning of the data should be preserved, but only a specific part needs to be anonymized.  The column's value can be excluded from "general" anonymization, but included in a specific definition.  For instance:

```xml
<Column Name="actions">
    <Exclusions>
        <Exclude Like="Some action performed by user: %"/>
   </Exclusions>
   <Function>.....</Function>
</Column>
<Column Name="actions">
    <Exclusions>
        <Exclude NotLike="Some action performed by user: %"/>
    </Exclusions>
    <Function>com.strider.dataanonymizer.functions.CoreFunctions.generateStringFromPattern</Function>
    <Parameters>
        <Parameter Name="regex" Value="Some action performed by user: [A-Z]{1}[a-z]{6}"/>
    </Parameters>
</Column>
```

Thanks,

Zaahid