### PR TITLE
Exclusion should set default 'update' value

### DIFF
--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
@@ -470,7 +470,9 @@ public class DatabaseAnonymizer implements IAnonymizer {
                 columnIndexes.put(columnName, columnIndex);
             }
             if (isExcludedColumn(db, row, column)) {
-                log.debug("Excluding column: " + columnName + " with value: " + row.getString(columnName));
+                String columnValue = row.getString(columnName);
+                updateStmt.setString(columnIndexes.get(columnName), columnValue);
+                log.debug("Excluding column: " + columnName + " with value: " + columnValue);
                 continue;
             }
             

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Column.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/requirement/Column.java
@@ -94,16 +94,16 @@ public class Column {
      * @return List<Exclude>
      */
     public List<Exclude> getExclusions() {
-        if (exclusions == null && ignoreEmpty != null && ignoreEmpty.equals("true")) {
+        List<Exclude> lst = new ArrayList<>();
+        if (exclusions != null && !exclusions.isEmpty()) {
+            lst.addAll(exclusions);
+        }
+        if (ignoreEmpty != null && ignoreEmpty.equals("true")) {
             Exclude exc = new Exclude();
             exc.setIgnoreEmpty();
-            exclusions = new ArrayList<>();
-            exclusions.add(exc);
+            lst.add(exc);
         }
-        if (this.exclusions != null) {
-            return unmodifiableList(this.exclusions);
-        }
-        return null;
+        return unmodifiableList(lst);
     }
     
     /**


### PR DESCRIPTION
If a column is completely excluded, the column's current value needed to be set (was causing SQLException for excluded value).

Also allowing "IgnoreEmpty" on column attribute even if <Exclusions> are set.  Since schema allows it, ignoring the attribute can cause confusion.