### PR TITLE
Fix for null values in excluded columns

### DIFF
--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/DatabaseAnonymizer.java
@@ -187,12 +187,12 @@ public class DatabaseAnonymizer implements IAnonymizer {
 
                 if (col != null && col.length() != 0) {
                     if (eq != null) {
-                        query.append(separator).append(col).append(" != ?");
+                        query.append(separator).append("(").append(col).append(" != ? OR ").append(col).append(" IS NULL)");
                         params.add(eq);
                         separator = " AND ";
                     }
                     if (lk != null && lk.length() != 0) {
-                        query.append(separator).append(col).append(" NOT LIKE ?");
+                        query.append(separator).append("(").append(col).append(" NOT LIKE ? OR ").append(col).append(" IS NULL)");
                         params.add(lk);
                         separator = " AND ";
                     }
@@ -223,7 +223,7 @@ public class DatabaseAnonymizer implements IAnonymizer {
 
             }
             
-            if (query.indexOf(" AND ") != -1) {
+            if (query.indexOf(" WHERE (") != -1) {
                 query.append(")");
             }
         }

--- a/DataAnonymizer/src/main/java/com/strider/dataanonymizer/functions/CoreFunctions.java
+++ b/DataAnonymizer/src/main/java/com/strider/dataanonymizer/functions/CoreFunctions.java
@@ -146,9 +146,9 @@ public class CoreFunctions {
     private String getPredictableShuffledValueFor(String name, String value) {
         if (!predictableShuffle.containsKey(name)) {
             List<String> list = stringLists.get(name);
-            List<String> shuffled = new ArrayList<String>(list);
+            List<String> shuffled = new ArrayList<>(list);
             Collections.shuffle(shuffled);
-            
+
             Map<String, String> smap = new HashMap<>();
             Iterator<String> lit = list.iterator();
             Iterator<String> sit = shuffled.iterator();
@@ -216,7 +216,10 @@ public class CoreFunctions {
             }
             rs.close();
             stmt.close();
-            
+            if (values.isEmpty()) {
+                // TODO: throw a meaningful exception here
+                log.error("!!! Database column " + keyName + " did not return any values");
+            }
             stringLists.put(keyName, values);
         }
     }


### PR DESCRIPTION
This fixes an issue with exclusions - adding an exclusion on a column automatically filtered out NULL values (something MySQL at least seems to do):

```sql
SELECT * FROM table WHERE column != 'value'
```
will not return rows where column IS NULL.  The simplest solution is to add

```sql
SELECT * FROM table WHERE (column != 'value' OR column IS NULL)
```
The query builder may filter out NULLs after, but it seems to work well.  I have not tested this on SQL Server or Oracle, but both T-SQL and PL/SQL support the syntax (it seems).

Also fixed an issue with a closing parantheses for queries with single exclusion.

Added log error message when using values from a database table's column, if the table column doesn't contain values.